### PR TITLE
allow using as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod solana {
+    pub mod parser;
+    pub mod structs;
+}


### PR DESCRIPTION
I ran into a problem when I tried using this as a library. I don't quite understand why the crate is designed like this with a `solana` module inside instead of using a `lib` package, but this seems to be good enough to use the library 

```
use solana_parser::solana::parser::parse_transaction;
```
ideally you'd want to move the parser up a level and use it as `solana_parser::parser::parse_transaction` but if you have good reasons to use the `solana` name, I can live with it