### PR TITLE
update solana Hash invocation to latest

### DIFF
--- a/src/solana/parser.rs
+++ b/src/solana/parser.rs
@@ -251,7 +251,7 @@ Parse Block Hash
 fn parse_block_hash(tx_body_remainder: &[u8]) -> Result<(Hash, &[u8]), Box<dyn std::error::Error>> {
     validate_length(tx_body_remainder, LEN_SOL_ACCOUNT_KEY_BYTES, "Block Hash")?;
     let hash_bytes: &[u8] = &tx_body_remainder[0..LEN_SOL_ACCOUNT_KEY_BYTES];
-    let block_hash = Hash::new(hash_bytes);
+    let block_hash = Hash::new_from_array(hash_bytes.try_into().unwrap());
     Ok((
         block_hash,
         &tx_body_remainder[LEN_SOL_ACCOUNT_KEY_BYTES..tx_body_remainder.len()],


### PR DESCRIPTION
When running `cargo install --lib .` to install this library I got the following error [0]

This can be fixed by moving away from a now-deprecated method to an explicit static constructor 

Manpage: https://docs.rs/solana-sdk/latest/solana_sdk/hash/struct.Hash.html

[0] 

```bash
...
     Locking 222 packages to latest compatible versions
      Adding bincode v1.3.3 (available: v2.0.1)
   Compiling solana_parser v0.1.0 (/Users/brendanryan/stripe/bridge/solana-parser)
warning: use of deprecated associated function `solana_sdk::hash::Hash::new`: Use 'Hash::new_from_array' instead
   --> src/solana/parser.rs:254:28
    |
254 |     let block_hash = Hash::new(hash_bytes);
    |                            ^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `solana_parser` (lib) generated 1 warning
warning: `solana_parser` (bin "solana_parser") generated 1 warning (1 duplicate)
    Finished `release` profile [optimized] target(s) in 3.36s
   Replacing /Users/brendanryan/.cargo/bin/solana_parser
    Replaced package `solana_parser v0.1.0 (/Users/brendanryan/stripe/bridge/solana-parser)` with `solana_parser v0.1.0 (/Users/brendanryan/stripe/bridge/solana-parser)` (executable `solana_parser`)
```